### PR TITLE
feat: add cluster header + connection name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "would-you",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Would you rather die or use this bot. You got the choice",
   "main": "dist/cluster.js",
   "scripts": {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -32,6 +32,10 @@ export interface IQueueMessage {
   };
   channelId: string | null;
   retries: number;
+  location: {
+    shard: number;
+    cluster: number;
+  };
 }
 export type Result<T, E extends Error = Error> =
   | { success: true; result: T }

--- a/src/util/dailyMessage.ts
+++ b/src/util/dailyMessage.ts
@@ -16,7 +16,7 @@ export default class DailyMessage {
   async listen() {
     console.log(this.client.cluster.count);
     const URL = process.env.RABBITMQ_URL || "fallback";
-    const connection = await amqplib.connect(URL);
+    const connection = await amqplib.connect(URL, { clientProperties: { connection_name: `client-cluster-${this.client.cluster.id}` } });
     let QUEUE = `cluster-${this.client.cluster.id}`;
     if (connection) {
       const channel = await connection.createChannel();
@@ -25,7 +25,6 @@ export default class DailyMessage {
         await channel.assertQueue(QUEUE, {
           durable: false,
           deadLetterExchange: "DLX",
-
           deadLetterRoutingKey: "nVZzaJrwJ9",
         });
         channel.consume(QUEUE, async (message) => {
@@ -74,6 +73,7 @@ export default class DailyMessage {
     message: IQueueMessage,
     properties: MessageProperties,
   ): Promise<Result<string>> {
+    console.log(message)
     if (message.channelId == null) {
       return {
         success: false,
@@ -210,7 +210,7 @@ export default class DailyMessage {
     reason: string,
     message: amqplib.Message,
   ) {
-    const headers = { rejectionCause: reason };
+    const headers = { rejectionCause: reason, cluster: this.client.cluster.id};
     channel.publish("DLX", "key", message.content, {
       headers: headers,
       messageId: message.properties.messageId,


### PR DESCRIPTION
Added a connection name to easily see what cluster is connected to RabbitMQ

## Description

**Link to the issue (if applicable)**:
Provide a link to the related issue (e.g., #[issue_number]).

**Description**:
Fix bug

## Changes Made

List the changes you made in this PR.

## Testing
Ran the whole setup when everything is setup correctly in discord and also did it with faulty configuration. It added the cluster id to the Dead Letter Message.

## Screenshots (if applicable)

#### BEFORE 
![image](https://github.com/Would-You-Bot/client/assets/37250273/31faf66a-b849-43ab-9c99-7d602d45b0a7)

#### AFTER
![image](https://github.com/Would-You-Bot/client/assets/37250273/685b5622-b3f5-4982-970e-22e88ef513c4)


## Additional Notes

When testing I figured out that the webhook doesn't get updated when you change channels.
