### PR TITLE
feat: daily message modal display current settings in modal

### DIFF
--- a/src/buttons/dailyTasks/dailyInterval.ts
+++ b/src/buttons/dailyTasks/dailyInterval.ts
@@ -34,7 +34,11 @@ function isFormat(str: string) {
 const button: Button = {
   name: "dailyInterval",
   execute: async (interaction, client, guildDb) => {
-    await interaction.showModal(modalObject);
+    const newModalObject = JSON.parse(JSON.stringify(modalObject));
+    newModalObject.components[0].components[0].placeholder =
+      guildDb.dailyInterval;
+
+    await interaction.showModal(newModalObject);
 
     interaction
       .awaitModalSubmit({

--- a/src/buttons/dailyTasks/dailyTimezone.ts
+++ b/src/buttons/dailyTasks/dailyTimezone.ts
@@ -49,7 +49,11 @@ function dateType(tz: string) {
 const button: Button = {
   name: "dailyTimezone",
   execute: async (interaction, client, guildDb) => {
-    await interaction.showModal(modalObject);
+    const newModalObject = JSON.parse(JSON.stringify(modalObject));
+    newModalObject.components[0].components[0].placeholder =
+      guildDb.dailyTimezone;
+
+    await interaction.showModal(newModalObject);
 
     interaction
       .awaitModalSubmit({


### PR DESCRIPTION
## Description

**Description**:
Added the guild's current settings for the daily messages to the timezone and interval modals as placeholders

## Changes Made
A deep copy of the object and sending that new payload as a modal

## Testing
I ran the bot using  `pnpm rum dev` and changes did not show any errors or conflicts

## Screenshots (if applicable)
![](https://i.imgur.com/kJ0gps3.png)
